### PR TITLE
refactor: Refactor database schema to use serial and integer types in…

### DIFF
--- a/drizzle/schema/tables/inventory/assetLoan.ts
+++ b/drizzle/schema/tables/inventory/assetLoan.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   date,
   text,
@@ -13,8 +13,8 @@ import { assetLoanStatus } from 'drizzle/schema/enums/inventory'
 import { relations } from 'drizzle-orm'
 
 export const assetLoan = pgTable('asset_loan', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id, { onDelete: 'cascade' })
     .notNull(),
   beneficiaryInstitution: varchar('beneficiary_institution', {

--- a/drizzle/schema/tables/inventory/assetValue.ts
+++ b/drizzle/schema/tables/inventory/assetValue.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   date,
   decimal,
@@ -12,8 +12,8 @@ import { item } from './item/item'
 import { relations } from 'drizzle-orm'
 
 export const assetValue = pgTable('asset_value', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id, { onDelete: 'cascade' })
     .notNull()
     .unique(),

--- a/drizzle/schema/tables/inventory/category.ts
+++ b/drizzle/schema/tables/inventory/category.ts
@@ -1,22 +1,22 @@
 import {
   pgTable,
-  uuid,
   varchar,
   text,
   integer,
   decimal,
   boolean,
   timestamp,
+  serial,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 import { item } from './item/item'
 
 export const category = pgTable('category', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   code: varchar('code', { length: 20 }).notNull().unique(),
   name: varchar('name', { length: 100 }).notNull(),
   description: text('description'),
-  parentCategoryId: uuid('parent_category_id'),
+  parentCategoryId: integer('parent_category_id'),
   standardUsefulLife: integer('standard_useful_life'),
   depreciationPercentage: decimal('depreciation_percentage', {
     precision: 5,

--- a/drizzle/schema/tables/inventory/certificate.ts
+++ b/drizzle/schema/tables/inventory/certificate.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   integer,
   date,
   timestamp,
@@ -16,7 +16,7 @@ import { relations } from 'drizzle-orm'
 import { item } from './item/item'
 
 export const certificate = pgTable('certificate', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   number: integer('number').notNull().unique(),
   date: date('date'),
   type: certificateType('type'),

--- a/drizzle/schema/tables/inventory/color.ts
+++ b/drizzle/schema/tables/inventory/color.ts
@@ -1,16 +1,16 @@
 import {
   pgTable,
-  uuid,
   varchar,
   text,
   timestamp,
   boolean,
+  serial,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 import { itemColor } from './item/itemColor'
 
 export const color = pgTable('color', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 50 }).notNull(),
   hexCode: varchar('hex_code', { length: 7 }),
   description: text('description'),

--- a/drizzle/schema/tables/inventory/condition.ts
+++ b/drizzle/schema/tables/inventory/condition.ts
@@ -1,16 +1,16 @@
 import {
   pgTable,
-  uuid,
   varchar,
   text,
   boolean,
   timestamp,
+  serial,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 import { item } from './item/item'
 
 export const condition = pgTable('condition', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 50 }).notNull(),
   description: text('description'),
   requiresMaintenance: boolean('requires_maintenance').default(false),

--- a/drizzle/schema/tables/inventory/depreciation.ts
+++ b/drizzle/schema/tables/inventory/depreciation.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   date,
   decimal,
   timestamp,
@@ -11,8 +11,8 @@ import { user } from '../users/user'
 import { relations } from 'drizzle-orm'
 
 export const depreciation = pgTable('depreciation', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id, { onDelete: 'cascade' })
     .notNull(),
   depreciationDate: date('depreciation_date').notNull(),

--- a/drizzle/schema/tables/inventory/exitDetail.ts
+++ b/drizzle/schema/tables/inventory/exitDetail.ts
@@ -1,6 +1,7 @@
 import {
   pgTable,
-  uuid,
+  serial,
+  integer,
   decimal,
   varchar,
   text,
@@ -14,11 +15,11 @@ import { relations } from 'drizzle-orm'
 export const exitDetail = pgTable(
   'exit_detail',
   {
-    id: uuid('id').primaryKey().defaultRandom(),
-    processId: uuid('process_id')
+    id: serial('id').primaryKey(),
+    processId: integer('process_id')
       .references(() => exitProcess.id, { onDelete: 'cascade' })
       .notNull(),
-    itemId: uuid('item_id')
+    itemId: integer('item_id')
       .references(() => item.id)
       .notNull(),
     appraisalValue: decimal('appraisal_value', { precision: 12, scale: 2 }),

--- a/drizzle/schema/tables/inventory/exitProcess.ts
+++ b/drizzle/schema/tables/inventory/exitProcess.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   date,
   timestamp,
@@ -16,7 +16,7 @@ import { relations } from 'drizzle-orm'
 import { exitDetail } from './exitDetail'
 
 export const exitProcess = pgTable('exit_process', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   processCode: varchar('process_code', { length: 50 }).notNull().unique(),
   type: exitProcessType('type').notNull(),
   startDate: date('start_date').notNull(),

--- a/drizzle/schema/tables/inventory/insuranceClaim.ts
+++ b/drizzle/schema/tables/inventory/insuranceClaim.ts
@@ -1,6 +1,7 @@
 import {
   pgTable,
-  uuid,
+  serial,
+  integer,
   date,
   decimal,
   text,
@@ -13,11 +14,11 @@ import { claimStatus } from 'drizzle/schema/enums/inventory'
 import { relations } from 'drizzle-orm'
 
 export const insuranceClaim = pgTable('insurance_claim', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  policyId: uuid('policy_id')
+  id: serial('id').primaryKey(),
+  policyId: integer('policy_id')
     .references(() => insurancePolicy.id)
     .notNull(),
-  itemId: uuid('item_id')
+  itemId: integer('item_id')
     .references(() => item.id)
     .notNull(),
   claimDate: date('claim_date').notNull(),

--- a/drizzle/schema/tables/inventory/insurancePolicy.ts
+++ b/drizzle/schema/tables/inventory/insurancePolicy.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   date,
   decimal,
@@ -14,7 +14,7 @@ import { insuranceClaim } from './insuranceClaim'
 import { item } from './item/item'
 
 export const insurancePolicy = pgTable('insurance_policy', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   policyNumber: varchar('policy_number', { length: 50 }).notNull().unique(),
   insuranceCompany: varchar('insurance_company', { length: 255 }).notNull(),
   policyType: varchar('policy_type', { length: 100 }),

--- a/drizzle/schema/tables/inventory/insuredAssetDetail.ts
+++ b/drizzle/schema/tables/inventory/insuredAssetDetail.ts
@@ -1,6 +1,7 @@
 import {
   pgTable,
-  uuid,
+  serial,
+  integer,
   decimal,
   text,
   timestamp,
@@ -13,11 +14,11 @@ import { relations } from 'drizzle-orm'
 export const insuredAssetDetail = pgTable(
   'insured_asset_detail',
   {
-    id: uuid('id').primaryKey().defaultRandom(),
-    policyId: uuid('policy_id')
+    id: serial('id').primaryKey(),
+    policyId: integer('policy_id')
       .references(() => insurancePolicy.id, { onDelete: 'cascade' })
       .notNull(),
-    itemId: uuid('item_id')
+    itemId: integer('item_id')
       .references(() => item.id, { onDelete: 'cascade' })
       .notNull(),
     insuredValue: decimal('insured_value', {

--- a/drizzle/schema/tables/inventory/item/item.ts
+++ b/drizzle/schema/tables/inventory/item/item.ts
@@ -1,12 +1,12 @@
 import {
   pgTable,
-  uuid,
   integer,
   varchar,
   text,
   date,
   boolean,
   timestamp,
+  serial,
 } from 'drizzle-orm/pg-core'
 import { normativeType, origin } from 'drizzle/schema/enums/inventory'
 import { user } from '../../users/user'
@@ -34,23 +34,23 @@ import { label } from '../../labeling/label'
 import { verificationDetail } from '../../reports/verificationDetail'
 
 export const item = pgTable('item', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   assetCode: integer('asset_code').notNull().unique(),
   previousCode: varchar('previous_code', { length: 50 }),
   identifier: varchar('identifier', { length: 50 }).unique(),
-  certificateId: uuid('certificate_id').references(() => certificate.id),
-  itemTypeId: uuid('item_type_id')
+  certificateId: integer('certificate_id').references(() => certificate.id),
+  itemTypeId: integer('item_type_id')
     .references(() => itemType.id)
     .notNull(),
   name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
-  categoryId: uuid('category_id')
+  categoryId: integer('category_id')
     .references(() => category.id)
     .notNull(),
-  statusId: uuid('status_id')
+  statusId: integer('status_id')
     .references(() => status.id)
     .notNull(),
-  conditionId: uuid('condition_id').references(() => condition.id),
+  conditionId: integer('condition_id').references(() => condition.id),
   normativeType: normativeType('normative_type').notNull(),
   registrationDate: timestamp('registration_date', {
     withTimezone: true,
@@ -80,10 +80,10 @@ export const item = pgTable('item', {
   notes: text('notes'),
   observations: text('observations'),
   availableForLoan: boolean('available_for_loan').default(true),
-  locationId: uuid('location_id').references(() => location.id),
+  locationId: integer('location_id').references(() => location.id),
   custodianId: integer('custodian_id').references(() => user.id),
   activeCustodian: boolean('active_custodian').default(true),
-  insurancePolicyId: uuid('insurance_policy_id').references(
+  insurancePolicyId: integer('insurance_policy_id').references(
     () => insurancePolicy.id,
   ),
   enabled: boolean('enabled').default(true),

--- a/drizzle/schema/tables/inventory/item/itemColor.ts
+++ b/drizzle/schema/tables/inventory/item/itemColor.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   integer,
   boolean,
   timestamp,
@@ -13,11 +13,11 @@ import { relations } from 'drizzle-orm'
 export const itemColor = pgTable(
   'item_color',
   {
-    id: uuid('id').primaryKey().defaultRandom(),
-    itemId: uuid('item_id')
+    id: serial('id').primaryKey(),
+    itemId: integer('item_id')
       .references(() => item.id, { onDelete: 'cascade' })
       .notNull(),
-    colorId: uuid('color_id')
+    colorId: integer('color_id')
       .references(() => color.id)
       .notNull(),
     percentage: integer('percentage'),

--- a/drizzle/schema/tables/inventory/item/itemImage.ts
+++ b/drizzle/schema/tables/inventory/item/itemImage.ts
@@ -1,6 +1,7 @@
 import {
   pgTable,
-  uuid,
+  serial,
+  integer,
   varchar,
   timestamp,
   boolean,
@@ -11,8 +12,8 @@ import { item } from './item'
 import { relations } from 'drizzle-orm'
 
 export const itemImage = pgTable('item_image', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id, { onDelete: 'cascade' })
     .notNull(),
   filePath: varchar('file_path', { length: 255 }).notNull(),

--- a/drizzle/schema/tables/inventory/item/itemMaterial.ts
+++ b/drizzle/schema/tables/inventory/item/itemMaterial.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   integer,
   boolean,
   timestamp,
@@ -13,11 +13,11 @@ import { relations } from 'drizzle-orm'
 export const itemMaterial = pgTable(
   'item_material',
   {
-    id: uuid('id').primaryKey().defaultRandom(),
-    itemId: uuid('item_id')
+    id: serial('id').primaryKey(),
+    itemId: integer('item_id')
       .references(() => item.id, { onDelete: 'cascade' })
       .notNull(),
-    materialId: uuid('material_id')
+    materialId: integer('material_id')
       .references(() => material.id)
       .notNull(),
     percentage: integer('percentage'),

--- a/drizzle/schema/tables/inventory/itemType.ts
+++ b/drizzle/schema/tables/inventory/itemType.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   timestamp,
@@ -10,7 +10,7 @@ import { relations } from 'drizzle-orm'
 import { item } from './item/item'
 
 export const itemType = pgTable('item_type', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   code: varchar('code', { length: 20 }).notNull(),
   name: varchar('name', { length: 100 }).notNull(),
   description: text('description'),

--- a/drizzle/schema/tables/inventory/maintenance.ts
+++ b/drizzle/schema/tables/inventory/maintenance.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   date,
   varchar,
   text,
@@ -14,10 +14,11 @@ import {
   maintenanceType,
 } from 'drizzle/schema/enums/inventory'
 import { user } from '../users/user'
+import { relations } from 'drizzle-orm'
 
 export const maintenance = pgTable('maintenance', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id, { onDelete: 'cascade' })
     .notNull(),
   maintenanceDate: date('maintenance_date').notNull(),
@@ -42,3 +43,14 @@ export const maintenance = pgTable('maintenance', {
     mode: 'date',
   }).defaultNow(),
 })
+
+export const maintenanceRelations = relations(maintenance, ({ one }) => ({
+  item: one(item, {
+    fields: [maintenance.itemId],
+    references: [item.id],
+  }),
+  responsible: one(user, {
+    fields: [maintenance.responsibleId],
+    references: [user.id],
+  }),
+}))

--- a/drizzle/schema/tables/inventory/material.ts
+++ b/drizzle/schema/tables/inventory/material.ts
@@ -1,16 +1,16 @@
 import {
   pgTable,
-  uuid,
   varchar,
   text,
   timestamp,
   boolean,
+  serial,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 import { itemMaterial } from './item/itemMaterial'
 
 export const material = pgTable('material', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 100 }).notNull(),
   description: text('description'),
   materialType: varchar('material_type', { length: 50 }),

--- a/drizzle/schema/tables/inventory/movement.ts
+++ b/drizzle/schema/tables/inventory/movement.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   timestamp,
   text,
   varchar,
@@ -10,14 +10,16 @@ import { movementType } from 'drizzle/schema/enums/locations'
 import { item } from './item/item'
 import { location } from '../locations/location'
 import { user } from '../users/user'
+import { relations } from 'drizzle-orm'
+
 export const movement = pgTable('movement', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id)
     .notNull(),
   movementType: movementType('movement_type').notNull(),
-  originLocationId: uuid('origin_location_id').references(() => location.id),
-  destinationLocationId: uuid('destination_location_id').references(
+  originLocationId: integer('origin_location_id').references(() => location.id),
+  destinationLocationId: integer('destination_location_id').references(
     () => location.id,
   ),
   movementDate: timestamp('movement_date', {
@@ -27,7 +29,7 @@ export const movement = pgTable('movement', {
   userId: integer('user_id')
     .references(() => user.id)
     .notNull(),
-  loanId: uuid('loan_id'), // Will reference loan table
+  loanId: integer('loan_id'), // Will reference loan table
   observations: text('observations'),
   reason: varchar('reason', { length: 255 }),
   transferCertificate: varchar('transfer_certificate', { length: 50 }),
@@ -36,3 +38,22 @@ export const movement = pgTable('movement', {
     mode: 'date',
   }).defaultNow(),
 })
+
+export const movementRelations = relations(movement, ({ one }) => ({
+  item: one(item, {
+    fields: [movement.itemId],
+    references: [item.id],
+  }),
+  originLocation: one(location, {
+    fields: [movement.originLocationId],
+    references: [location.id],
+  }),
+  destinationLocation: one(location, {
+    fields: [movement.destinationLocationId],
+    references: [location.id],
+  }),
+  user: one(user, {
+    fields: [movement.userId],
+    references: [user.id],
+  }),
+}))

--- a/drizzle/schema/tables/inventory/status.ts
+++ b/drizzle/schema/tables/inventory/status.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   boolean,
@@ -12,7 +12,7 @@ import { statusChange } from './statusChange'
 import { loanDetail } from '../loans/loanDetail'
 
 export const status = pgTable('status', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 50 }).notNull().unique(),
   description: text('description'),
   requiresMaintenance: boolean('requires_maintenance').default(false),

--- a/drizzle/schema/tables/inventory/statusChange.ts
+++ b/drizzle/schema/tables/inventory/statusChange.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   timestamp,
   text,
   varchar,
@@ -10,14 +10,15 @@ import { item } from './item/item'
 import { status } from './status'
 import { user } from '../users/user'
 import { loan } from '../loans/loan'
+import { relations } from 'drizzle-orm'
 
 export const statusChange = pgTable('status_change', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id, { onDelete: 'cascade' })
     .notNull(),
-  previousStatusId: uuid('previous_status_id').references(() => status.id),
-  newStatusId: uuid('new_status_id')
+  previousStatusId: integer('previous_status_id').references(() => status.id),
+  newStatusId: integer('new_status_id')
     .references(() => status.id)
     .notNull(),
   changeDate: timestamp('change_date', {
@@ -27,7 +28,7 @@ export const statusChange = pgTable('status_change', {
   userId: integer('user_id')
     .references(() => user.id)
     .notNull(),
-  loanId: uuid('loan_id')
+  loanId: integer('loan_id')
     .references(() => loan.id)
     .notNull(),
   observations: text('observations'),
@@ -37,3 +38,28 @@ export const statusChange = pgTable('status_change', {
     mode: 'date',
   }).defaultNow(),
 })
+
+export const statusChangeRelations = relations(statusChange, ({ one }) => ({
+  item: one(item, {
+    fields: [statusChange.itemId],
+    references: [item.id],
+  }),
+  previousStatus: one(status, {
+    fields: [statusChange.previousStatusId],
+    references: [status.id],
+    relationName: 'previousStatus',
+  }),
+  newStatus: one(status, {
+    fields: [statusChange.newStatusId],
+    references: [status.id],
+    relationName: 'newStatus',
+  }),
+  user: one(user, {
+    fields: [statusChange.userId],
+    references: [user.id],
+  }),
+  loan: one(loan, {
+    fields: [statusChange.loanId],
+    references: [loan.id],
+  }),
+}))

--- a/drizzle/schema/tables/labeling/label.ts
+++ b/drizzle/schema/tables/labeling/label.ts
@@ -1,4 +1,10 @@
-import { pgTable, uuid, varchar, timestamp } from 'drizzle-orm/pg-core'
+import {
+  pgTable,
+  serial,
+  integer,
+  varchar,
+  timestamp,
+} from 'drizzle-orm/pg-core'
 import {
   labelType,
   labelFormat,
@@ -9,8 +15,8 @@ import { relations } from 'drizzle-orm'
 import { scanRecord } from './scanRecord'
 
 export const label = pgTable('label', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  itemId: uuid('item_id')
+  id: serial('id').primaryKey(),
+  itemId: integer('item_id')
     .references(() => item.id, { onDelete: 'cascade' })
     .notNull(),
   type: labelType('type').notNull(),

--- a/drizzle/schema/tables/labeling/labelTemplate.ts
+++ b/drizzle/schema/tables/labeling/labelTemplate.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   boolean,
@@ -8,9 +8,10 @@ import {
   integer,
 } from 'drizzle-orm/pg-core'
 import { user } from '../users/user'
+import { relations } from 'drizzle-orm'
 
 export const labelTemplate = pgTable('label_template', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 100 }).notNull().unique(),
   description: text('description'),
   configuration: text('configuration').notNull(),
@@ -28,3 +29,10 @@ export const labelTemplate = pgTable('label_template', {
     mode: 'date',
   }).defaultNow(),
 })
+
+export const labelTemplateRelations = relations(labelTemplate, ({ one }) => ({
+  creator: one(user, {
+    fields: [labelTemplate.creatorId],
+    references: [user.id],
+  }),
+}))

--- a/drizzle/schema/tables/labeling/scanRecord.ts
+++ b/drizzle/schema/tables/labeling/scanRecord.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   timestamp,
   text,
   varchar,
@@ -11,8 +11,8 @@ import { user } from '../users/user'
 import { relations } from 'drizzle-orm'
 
 export const scanRecord = pgTable('scan_record', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  labelId: uuid('label_id')
+  id: serial('id').primaryKey(),
+  labelId: integer('label_id')
     .references(() => label.id, { onDelete: 'cascade' })
     .notNull(),
   userId: integer('user_id')

--- a/drizzle/schema/tables/loans/loan.ts
+++ b/drizzle/schema/tables/loans/loan.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   timestamp,
   text,
@@ -15,7 +15,7 @@ import { loanHistory } from './loanHistory'
 import { responsibilityDocument } from './responsibilityDocument'
 
 export const loan = pgTable('loan', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   loanCode: varchar('loan_code', { length: 50 }).notNull().unique(),
   requestDate: timestamp('request_date', {
     withTimezone: true,

--- a/drizzle/schema/tables/loans/loanDetail.ts
+++ b/drizzle/schema/tables/loans/loanDetail.ts
@@ -1,6 +1,7 @@
 import {
   pgTable,
-  uuid,
+  serial,
+  integer,
   text,
   varchar,
   boolean,
@@ -15,15 +16,15 @@ import { relations } from 'drizzle-orm'
 export const loanDetail = pgTable(
   'loan_detail',
   {
-    id: uuid('id').primaryKey().defaultRandom(),
-    loanId: uuid('loan_id')
+    id: serial('id').primaryKey(),
+    loanId: integer('loan_id')
       .references(() => loan.id, { onDelete: 'cascade' })
       .notNull(),
-    itemId: uuid('item_id')
+    itemId: integer('item_id')
       .references(() => item.id)
       .notNull(),
-    exitStatusId: uuid('exit_status_id').references(() => status.id),
-    returnStatusId: uuid('return_status_id').references(() => status.id),
+    exitStatusId: integer('exit_status_id').references(() => status.id),
+    returnStatusId: integer('return_status_id').references(() => status.id),
     exitObservations: text('exit_observations'),
     returnObservations: text('return_observations'),
     exitImage: varchar('exit_image', { length: 255 }),

--- a/drizzle/schema/tables/loans/loanHistory.ts
+++ b/drizzle/schema/tables/loans/loanHistory.ts
@@ -1,11 +1,12 @@
-import { pgTable, uuid, timestamp, text, integer } from 'drizzle-orm/pg-core'
+import { pgTable, serial, timestamp, text, integer } from 'drizzle-orm/pg-core'
 import { loan } from './loan'
 import { loanStatus } from 'drizzle/schema/enums/loans'
 import { user } from '../users/user'
+import { relations } from 'drizzle-orm'
 
 export const loanHistory = pgTable('loan_history', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  loanId: uuid('loan_id')
+  id: serial('id').primaryKey(),
+  loanId: integer('loan_id')
     .references(() => loan.id, { onDelete: 'cascade' })
     .notNull(),
   previousStatus: loanStatus('previous_status'),
@@ -23,3 +24,14 @@ export const loanHistory = pgTable('loan_history', {
     mode: 'date',
   }).defaultNow(),
 })
+
+export const loanHistoryRelations = relations(loanHistory, ({ one }) => ({
+  loan: one(loan, {
+    fields: [loanHistory.loanId],
+    references: [loan.id],
+  }),
+  user: one(user, {
+    fields: [loanHistory.userId],
+    references: [user.id],
+  }),
+}))

--- a/drizzle/schema/tables/loans/responsibilityDocument.ts
+++ b/drizzle/schema/tables/loans/responsibilityDocument.ts
@@ -1,10 +1,17 @@
-import { pgTable, uuid, varchar, timestamp, integer } from 'drizzle-orm/pg-core'
+import {
+  pgTable,
+  serial,
+  varchar,
+  timestamp,
+  integer,
+} from 'drizzle-orm/pg-core'
 import { loan } from './loan'
 import { documentType } from 'drizzle/schema/enums/loans'
+import { relations } from 'drizzle-orm'
 
 export const responsibilityDocument = pgTable('responsibility_document', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  loanId: uuid('loan_id')
+  id: serial('id').primaryKey(),
+  loanId: integer('loan_id')
     .references(() => loan.id, { onDelete: 'cascade' })
     .notNull(),
   documentUrl: varchar('document_url', { length: 255 }).notNull(),
@@ -28,3 +35,13 @@ export const responsibilityDocument = pgTable('responsibility_document', {
     mode: 'date',
   }).defaultNow(),
 })
+
+export const responsibilityDocumentRelations = relations(
+  responsibilityDocument,
+  ({ one }) => ({
+    loan: one(loan, {
+      fields: [responsibilityDocument.loanId],
+      references: [loan.id],
+    }),
+  }),
+)

--- a/drizzle/schema/tables/locations/location.ts
+++ b/drizzle/schema/tables/locations/location.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   integer,
@@ -14,11 +14,11 @@ import { item } from '../inventory/item/item'
 import { movement } from '../inventory/movement'
 
 export const location = pgTable('location', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
-  warehouseId: uuid('warehouse_id').references(() => warehouse.id),
-  parentLocationId: uuid('parent_location_id').references(() => location.id),
+  warehouseId: integer('warehouse_id').references(() => warehouse.id),
+  parentLocationId: integer('parent_location_id'),
   type: locationType('type').notNull(),
   building: varchar('building', { length: 100 }),
   floor: varchar('floor', { length: 50 }),

--- a/drizzle/schema/tables/locations/warehouse.ts
+++ b/drizzle/schema/tables/locations/warehouse.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   boolean,
@@ -12,7 +12,7 @@ import { relations } from 'drizzle-orm'
 import { location } from './location'
 
 export const warehouse = pgTable('warehouse', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 255 }).notNull(),
   location: varchar('location', { length: 255 }),
   responsibleId: integer('responsible_id').references(() => user.id),

--- a/drizzle/schema/tables/notifications/deliveryRecord.ts
+++ b/drizzle/schema/tables/notifications/deliveryRecord.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, integer, text, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, serial, integer, text, timestamp } from 'drizzle-orm/pg-core'
 import { notification } from './notification'
 import {
   notificationChannel,
@@ -7,8 +7,8 @@ import {
 import { relations } from 'drizzle-orm'
 
 export const deliveryRecord = pgTable('delivery_record', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  notificationId: uuid('notification_id')
+  id: serial('id').primaryKey(),
+  notificationId: integer('notification_id')
     .references(() => notification.id, { onDelete: 'cascade' })
     .notNull(),
   channel: notificationChannel('channel').notNull(),

--- a/drizzle/schema/tables/notifications/notification.ts
+++ b/drizzle/schema/tables/notifications/notification.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   timestamp,
@@ -15,7 +15,7 @@ import { relations } from 'drizzle-orm'
 import { deliveryRecord } from './deliveryRecord'
 
 export const notification = pgTable('notification', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   userId: integer('user_id')
     .references(() => user.id, { onDelete: 'cascade' })
     .notNull(),
@@ -32,7 +32,7 @@ export const notification = pgTable('notification', {
   }),
   status: notificationStatus('status').notNull().default('PENDING'),
   actionUrl: varchar('action_url', { length: 255 }),
-  entityId: uuid('entity_id'),
+  entityId: integer('entity_id'),
   entityType: varchar('entity_type', { length: 50 }),
   updateDate: timestamp('update_date', {
     withTimezone: true,

--- a/drizzle/schema/tables/notifications/notificationPreference.ts
+++ b/drizzle/schema/tables/notifications/notificationPreference.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   boolean,
   timestamp,
@@ -13,7 +13,7 @@ import { relations } from 'drizzle-orm'
 export const notificationPreference = pgTable(
   'notification_preference',
   {
-    id: uuid('id').primaryKey().defaultRandom(),
+    id: serial('id').primaryKey(),
     userId: integer('user_id')
       .references(() => user.id, { onDelete: 'cascade' })
       .notNull(),

--- a/drizzle/schema/tables/notifications/notificationTemplate.ts
+++ b/drizzle/schema/tables/notifications/notificationTemplate.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   boolean,
@@ -13,7 +13,7 @@ import {
 import { relations } from 'drizzle-orm'
 
 export const notificationTemplate = pgTable('notification_template', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   type: notificationType('type').notNull().unique(),
   templateTitle: text('template_title').notNull(),
   templateContent: text('template_content').notNull(),

--- a/drizzle/schema/tables/reports/generatedReport.ts
+++ b/drizzle/schema/tables/reports/generatedReport.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   timestamp,
   text,
@@ -13,7 +13,7 @@ import { user } from '../users/user'
 import { relations } from 'drizzle-orm'
 
 export const generatedReport = pgTable('generated_report', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 255 }).notNull(),
   type: reportType('type').notNull(),
   parameters: text('parameters'),

--- a/drizzle/schema/tables/reports/inventoryStatistics.ts
+++ b/drizzle/schema/tables/reports/inventoryStatistics.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   date,
   integer,
   decimal,
@@ -9,7 +9,7 @@ import {
 } from 'drizzle-orm/pg-core'
 
 export const inventoryStatistics = pgTable('inventory_statistics', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   date: date('date').notNull(),
   totalItems: integer('total_items').notNull(),
   totalCategories: integer('total_categories').notNull(),

--- a/drizzle/schema/tables/reports/physicalVerification.ts
+++ b/drizzle/schema/tables/reports/physicalVerification.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   date,
   timestamp,
@@ -13,7 +13,7 @@ import { relations } from 'drizzle-orm'
 import { verificationDetail } from './verificationDetail'
 
 export const physicalVerification = pgTable('physical_verification', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   code: varchar('code', { length: 50 }).notNull().unique(),
   startDate: date('start_date').notNull(),
   endDate: date('end_date'),

--- a/drizzle/schema/tables/reports/reportTemplate.ts
+++ b/drizzle/schema/tables/reports/reportTemplate.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   varchar,
   text,
   boolean,
@@ -9,9 +9,10 @@ import {
 } from 'drizzle-orm/pg-core'
 import { reportType } from 'drizzle/schema/enums/reports'
 import { user } from '../users/user'
+import { relations } from 'drizzle-orm'
 
 export const reportTemplate = pgTable('report_template', {
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: serial('id').primaryKey(),
   name: varchar('name', { length: 100 }).notNull().unique(),
   description: text('description'),
   type: reportType('type').notNull(),
@@ -30,3 +31,10 @@ export const reportTemplate = pgTable('report_template', {
     mode: 'date',
   }).defaultNow(),
 })
+
+export const reportTemplateRelations = relations(reportTemplate, ({ one }) => ({
+  creator: one(user, {
+    fields: [reportTemplate.creatorId],
+    references: [user.id],
+  }),
+}))

--- a/drizzle/schema/tables/reports/verificationDetail.ts
+++ b/drizzle/schema/tables/reports/verificationDetail.ts
@@ -1,6 +1,6 @@
 import {
   pgTable,
-  uuid,
+  serial,
   timestamp,
   text,
   varchar,
@@ -17,15 +17,15 @@ import { relations } from 'drizzle-orm'
 export const verificationDetail = pgTable(
   'verification_detail',
   {
-    id: uuid('id').primaryKey().defaultRandom(),
-    verificationId: uuid('verification_id')
+    id: serial('id').primaryKey(),
+    verificationId: integer('verification_id')
       .references(() => physicalVerification.id, { onDelete: 'cascade' })
       .notNull(),
-    itemId: uuid('item_id')
+    itemId: integer('item_id')
       .references(() => item.id)
       .notNull(),
     foundStatus: foundStatus('found_status').notNull(),
-    foundLocationId: uuid('found_location_id').references(() => location.id),
+    foundLocationId: integer('found_location_id').references(() => location.id),
     foundUserId: integer('found_user_id').references(() => user.id),
     observations: text('observations'),
     evidencePhoto: varchar('evidence_photo', { length: 255 }),

--- a/drizzle/schema/tables/users/user.ts
+++ b/drizzle/schema/tables/users/user.ts
@@ -1,7 +1,8 @@
 import { pgTable, varchar, serial, integer } from 'drizzle-orm/pg-core'
 import { person } from './person'
-import { userRole, userStatus, userType } from 'drizzle/schema'
 import { relations } from 'drizzle-orm'
+import { userStatus, userType } from 'drizzle/schema/enums/user'
+import { userRole } from './userRole'
 
 export const user = pgTable('users', {
   id: serial('id').primaryKey(),

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "webpack": true,
+    "tsConfigPath": "tsconfig.json"
   }
 }

--- a/src/core/categories/categories.controller.ts
+++ b/src/core/categories/categories.controller.ts
@@ -5,7 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
-  ParseUUIDPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -40,7 +40,7 @@ export class CategoriesController {
     summary: 'Get a category by id',
   })
   @ApiStandardResponse(CategoryResDto, HttpStatus.OK)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.service.findOne(id)
   }
 
@@ -61,7 +61,7 @@ export class CategoriesController {
   @ApiBody({ type: UpdateCategoryDto })
   @ApiStandardResponse(CategoryResDto, HttpStatus.OK)
   update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateCategoryDto,
   ) {
     return this.service.update(id, dto)
@@ -72,7 +72,7 @@ export class CategoriesController {
     summary: 'Delete a category by id',
   })
   @ApiStandardResponse(CategoryResDto, HttpStatus.OK)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIntPipe) id: number) {
     return this.service.remove(id)
   }
 }

--- a/src/core/categories/categories.service.ts
+++ b/src/core/categories/categories.service.ts
@@ -48,7 +48,7 @@ export class CategoriesService {
     }
   }
 
-  async findOne(id: string) {
+  async findOne(id: number) {
     const [record] = await this.dbService.db
       .select(this.categoriesWithoutDates)
       .from(category)
@@ -91,7 +91,7 @@ export class CategoriesService {
     return newCategory
   }
 
-  async update(id: string, dto: UpdateCategoryDto) {
+  async update(id: number, dto: UpdateCategoryDto) {
     await this.findOne(id)
 
     const updateData: Partial<UpdateCategoryDto> = {
@@ -108,7 +108,7 @@ export class CategoriesService {
     return updateCategory
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.findOne(id)
 
     const [deletedCategory] = await this.dbService.db

--- a/src/core/categories/dto/req/create-category.dto.ts
+++ b/src/core/categories/dto/req/create-category.dto.ts
@@ -34,10 +34,10 @@ export class CreateCategoryDto {
 
   @ApiProperty({
     description: 'parentCategoryId (is optional)',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    example: 1,
   })
   @IsOptional()
-  parentCategoryId?: string
+  parentCategoryId?: number
 
   @ApiProperty({
     description: 'standardUsefulLife (is optional)',

--- a/src/core/categories/dto/req/update-category.dto.ts
+++ b/src/core/categories/dto/req/update-category.dto.ts
@@ -40,9 +40,9 @@ export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {
 
   @ApiPropertyOptional({
     description: 'parentCategoryId (is optional)',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    example: 1,
   })
-  parentCategoryId?: string
+  parentCategoryId?: number
 
   @ApiPropertyOptional({
     description: 'standardUsefulLife (is optional)',

--- a/src/core/categories/dto/res/category-res.dto.ts
+++ b/src/core/categories/dto/res/category-res.dto.ts
@@ -5,7 +5,7 @@ export class CategoryResDto {
     description: 'id of the category',
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
-  id: string
+  id: number
 
   @ApiProperty({
     description: 'code of the category',
@@ -29,7 +29,7 @@ export class CategoryResDto {
     description: 'parentCategoryId of the category',
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
-  parentCategoryId: string
+  parentCategoryId: number
 
   @ApiProperty({
     description: 'standardUsefulLife of the category',

--- a/src/core/colors/colors.controller.ts
+++ b/src/core/colors/colors.controller.ts
@@ -5,7 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
-  ParseUUIDPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -40,7 +40,7 @@ export class ColorsController {
     summary: 'Obtener un color por id',
   })
   @ApiStandardResponse(ColorResDto, HttpStatus.OK)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.service.findOne(id)
   }
 
@@ -60,7 +60,7 @@ export class ColorsController {
   })
   @ApiBody({ type: UpdateColorDto })
   @ApiStandardResponse(ColorResDto, HttpStatus.OK)
-  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateColorDto) {
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateColorDto) {
     return this.service.update(id, dto)
   }
 
@@ -69,7 +69,7 @@ export class ColorsController {
     summary: 'Eliminar un color por id',
   })
   @ApiStandardResponse(ColorResDto, HttpStatus.OK)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIntPipe) id: number) {
     return this.service.remove(id)
   }
 }

--- a/src/core/colors/colors.service.ts
+++ b/src/core/colors/colors.service.ts
@@ -53,7 +53,7 @@ export class ColorsService {
     }
   }
 
-  async findOne(id: string) {
+  async findOne(id: number) {
     const [record] = await this.dbService.db
       .select(this.colorsWithoutDates)
       .from(color)
@@ -68,7 +68,7 @@ export class ColorsService {
     return plainToInstance(ColorResDto, record)
   }
 
-  async existByName(name?: string, excludeId?: string) {
+  async existByName(name?: string, excludeId?: number) {
     if (!name) return true
     const [record] = await this.dbService.db
       .select(this.colorsWithoutDates)
@@ -109,7 +109,7 @@ export class ColorsService {
     return plainToInstance(ColorResDto, newColor)
   }
 
-  async update(id: string, dto: UpdateColorDto) {
+  async update(id: number, dto: UpdateColorDto) {
     await this.findOne(id)
 
     const alreadyExistColor = await this.existByName(dto.name, id)
@@ -131,7 +131,7 @@ export class ColorsService {
     return plainToInstance(ColorResDto, updatedColor)
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.findOne(id)
 
     const [deletedColor] = await this.dbService.db

--- a/src/core/colors/dto/res/color-res.dto.ts
+++ b/src/core/colors/dto/res/color-res.dto.ts
@@ -7,7 +7,7 @@ export class ColorResDto {
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
   @Expose()
-  id: string
+  id: number
 
   @ApiProperty({
     description: 'nombre del color',

--- a/src/core/conditions/conditions.controller.ts
+++ b/src/core/conditions/conditions.controller.ts
@@ -5,7 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
-  ParseUUIDPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -40,7 +40,7 @@ export class ConditionsController {
     summary: 'Obtener una condición por id',
   })
   @ApiStandardResponse(ConditionResDto, HttpStatus.OK)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.service.findOne(id)
   }
 
@@ -61,7 +61,7 @@ export class ConditionsController {
   @ApiBody({ type: UpdateConditionDto })
   @ApiStandardResponse(ConditionResDto, HttpStatus.OK)
   update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateConditionDto,
   ) {
     return this.service.update(id, dto)
@@ -72,7 +72,7 @@ export class ConditionsController {
     summary: 'Eliminar una condición por id',
   })
   @ApiStandardResponse(ConditionResDto, HttpStatus.OK)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIntPipe) id: number) {
     return this.service.remove(id)
   }
 }

--- a/src/core/conditions/conditions.service.ts
+++ b/src/core/conditions/conditions.service.ts
@@ -53,7 +53,7 @@ export class ConditionsService {
     }
   }
 
-  async findOne(id: string) {
+  async findOne(id: number) {
     const [record] = await this.dbService.db
       .select(this.conditionsWithoutDates)
       .from(condition)
@@ -68,7 +68,7 @@ export class ConditionsService {
     return plainToInstance(ConditionResDto, record)
   }
 
-  async existByName(name?: string, excludeId?: string) {
+  async existByName(name?: string, excludeId?: number) {
     if (!name) return true
     const [record] = await this.dbService.db
       .select(this.conditionsWithoutDates)
@@ -109,7 +109,7 @@ export class ConditionsService {
     return plainToInstance(ConditionResDto, newCondition)
   }
 
-  async update(id: string, dto: UpdateConditionDto) {
+  async update(id: number, dto: UpdateConditionDto) {
     await this.findOne(id)
 
     const alreadyExistCondition = await this.existByName(dto.name, id)
@@ -131,7 +131,7 @@ export class ConditionsService {
     return plainToInstance(ConditionResDto, updatedCondition)
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.findOne(id)
 
     const [deletedCondition] = await this.dbService.db

--- a/src/core/conditions/dto/res/condition-res.dto.ts
+++ b/src/core/conditions/dto/res/condition-res.dto.ts
@@ -7,7 +7,7 @@ export class ConditionResDto {
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
   @Expose()
-  id: string
+  id: number
 
   @ApiProperty({
     description: 'nombre de la condición',

--- a/src/core/item-types/dto/res/item-type-res.dto.ts
+++ b/src/core/item-types/dto/res/item-type-res.dto.ts
@@ -7,7 +7,7 @@ export class ItemTypeResDto {
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
   @Expose()
-  id: string
+  id: number
 
   @ApiProperty({
     description: 'código del tipo de ítem',

--- a/src/core/item-types/item-types.controller.ts
+++ b/src/core/item-types/item-types.controller.ts
@@ -5,7 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
-  ParseUUIDPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -40,7 +40,7 @@ export class ItemTypesController {
     summary: 'Obtener un tipo de ítem por id',
   })
   @ApiStandardResponse(ItemTypeResDto, HttpStatus.OK)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.service.findOne(id)
   }
 
@@ -61,7 +61,7 @@ export class ItemTypesController {
   @ApiBody({ type: UpdateItemTypeDto })
   @ApiStandardResponse(ItemTypeResDto, HttpStatus.OK)
   update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateItemTypeDto,
   ) {
     return this.service.update(id, dto)
@@ -72,7 +72,7 @@ export class ItemTypesController {
     summary: 'Eliminar un tipo de ítem por id',
   })
   @ApiStandardResponse(ItemTypeResDto, HttpStatus.OK)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIntPipe) id: number) {
     return this.service.remove(id)
   }
 }

--- a/src/core/item-types/item-types.service.ts
+++ b/src/core/item-types/item-types.service.ts
@@ -53,7 +53,7 @@ export class ItemTypesService {
     }
   }
 
-  async findOne(id: string) {
+  async findOne(id: number) {
     const [record] = await this.dbService.db
       .select(this.itemTypesWithoutDates)
       .from(itemType)
@@ -66,7 +66,7 @@ export class ItemTypesService {
     return plainToInstance(ItemTypeResDto, record)
   }
 
-  async existByCode(code?: string, excludeId?: string) {
+  async existByCode(code?: string, excludeId?: number) {
     if (!code) return true
 
     const [alreadyExistItemType] = await this.dbService.db
@@ -108,7 +108,7 @@ export class ItemTypesService {
     return plainToInstance(ItemTypeResDto, newItemType)
   }
 
-  async update(id: string, dto: UpdateItemTypeDto) {
+  async update(id: number, dto: UpdateItemTypeDto) {
     await this.findOne(id)
 
     const alreadyExistItemType = await this.existByCode(dto.code, id)
@@ -130,7 +130,7 @@ export class ItemTypesService {
     return plainToInstance(ItemTypeResDto, updatedItemType)
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.findOne(id)
 
     const [deletedItemType] = await this.dbService.db

--- a/src/core/materials/dto/res/material-res.dto.ts
+++ b/src/core/materials/dto/res/material-res.dto.ts
@@ -7,7 +7,7 @@ export class MaterialResDto {
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
   @Expose()
-  id: string
+  id: number
 
   @ApiProperty({
     description: 'nombre del material',

--- a/src/core/materials/materials.controller.ts
+++ b/src/core/materials/materials.controller.ts
@@ -5,7 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
-  ParseUUIDPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -40,7 +40,7 @@ export class MaterialsController {
     summary: 'Obtener un material por id',
   })
   @ApiStandardResponse(MaterialResDto, HttpStatus.OK)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.service.findOne(id)
   }
 
@@ -61,7 +61,7 @@ export class MaterialsController {
   @ApiBody({ type: UpdateMaterialDto })
   @ApiStandardResponse(MaterialResDto, HttpStatus.OK)
   update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateMaterialDto,
   ) {
     return this.service.update(id, dto)
@@ -72,7 +72,7 @@ export class MaterialsController {
     summary: 'Eliminar un material por id',
   })
   @ApiStandardResponse(MaterialResDto, HttpStatus.OK)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIntPipe) id: number) {
     return this.service.remove(id)
   }
 }

--- a/src/core/materials/materials.service.ts
+++ b/src/core/materials/materials.service.ts
@@ -53,7 +53,7 @@ export class MaterialsService {
     }
   }
 
-  async findOne(id: string) {
+  async findOne(id: number) {
     const [record] = await this.dbService.db
       .select(this.materialsWithoutDates)
       .from(material)
@@ -68,7 +68,7 @@ export class MaterialsService {
     return plainToInstance(MaterialResDto, record)
   }
 
-  async existByName(name?: string, excludeId?: string) {
+  async existByName(name?: string, excludeId?: number) {
     if (!name) return true
     const [record] = await this.dbService.db
       .select(this.materialsWithoutDates)
@@ -109,7 +109,7 @@ export class MaterialsService {
     return plainToInstance(MaterialResDto, newMaterial)
   }
 
-  async update(id: string, dto: UpdateMaterialDto) {
+  async update(id: number, dto: UpdateMaterialDto) {
     await this.findOne(id)
 
     const alreadyExistMaterial = await this.existByName(dto.name, id)
@@ -131,7 +131,7 @@ export class MaterialsService {
     return plainToInstance(MaterialResDto, updatedMaterial)
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.findOne(id)
 
     const [deletedMaterial] = await this.dbService.db

--- a/src/core/states/dto/res/status-res.dto.ts
+++ b/src/core/states/dto/res/status-res.dto.ts
@@ -5,7 +5,7 @@ export class StatusResDto {
     description: 'id of the status',
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
-  id: string
+  id: number
 
   @ApiProperty({
     description: 'name of the status',

--- a/src/core/states/states.controller.ts
+++ b/src/core/states/states.controller.ts
@@ -5,7 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
-  ParseUUIDPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -40,7 +40,7 @@ export class StatesController {
     summary: 'Get a category by id',
   })
   @ApiStandardResponse(StatusResDto, HttpStatus.OK)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.service.findOne(id)
   }
 
@@ -60,7 +60,7 @@ export class StatesController {
   })
   @ApiBody({ type: UpdateStatusDto })
   @ApiStandardResponse(StatusResDto, HttpStatus.OK)
-  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateStatusDto) {
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateStatusDto) {
     return this.service.update(id, dto)
   }
 
@@ -69,7 +69,7 @@ export class StatesController {
     summary: 'Delete a category by id',
   })
   @ApiStandardResponse(StatusResDto, HttpStatus.OK)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIntPipe) id: number) {
     return this.service.remove(id)
   }
 }

--- a/src/core/states/states.service.ts
+++ b/src/core/states/states.service.ts
@@ -46,7 +46,7 @@ export class StatesService {
     }
   }
 
-  async findOne(id: string) {
+  async findOne(id: number) {
     const [record] = await this.dbService.db
       .select(this.statesWithoutDates)
       .from(status)
@@ -86,7 +86,7 @@ export class StatesService {
     return newStatus
   }
 
-  async update(id: string, dto: UpdateStatusDto) {
+  async update(id: number, dto: UpdateStatusDto) {
     await this.findOne(id)
 
     const updateData: Partial<UpdateStatusDto> = {
@@ -103,7 +103,7 @@ export class StatesService {
     return updateStatus
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.findOne(id)
 
     const [deletedStatus] = await this.dbService.db

--- a/src/core/warehouses/dto/req/create-warehouse.dto.ts
+++ b/src/core/warehouses/dto/req/create-warehouse.dto.ts
@@ -31,7 +31,7 @@ export class CreateWarehouseDto {
 
   @ApiProperty({
     description: 'ID del responsable del almacén (es opcional)',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    example: 1,
   })
   @IsNumber()
   @IsOptional()

--- a/src/core/warehouses/dto/req/update-warehouse.dto.ts
+++ b/src/core/warehouses/dto/req/update-warehouse.dto.ts
@@ -33,7 +33,7 @@ export class UpdateWarehouseDto extends PartialType(CreateWarehouseDto) {
 
   @ApiPropertyOptional({
     description: 'ID del responsable del almacén (es opcional)',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    example: 1,
   })
   @IsNumber()
   @IsOptional()

--- a/src/core/warehouses/dto/res/warehouse-res.dto.ts
+++ b/src/core/warehouses/dto/res/warehouse-res.dto.ts
@@ -7,7 +7,7 @@ export class WarehouseResDto {
     example: 'asdasd-asdasd-asdasd-asdasd',
   })
   @Expose()
-  id: string
+  id: number
 
   @ApiProperty({
     description: 'nombre del almacén',
@@ -25,10 +25,10 @@ export class WarehouseResDto {
 
   @ApiProperty({
     description: 'ID del responsable del almacén',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    example: 1,
   })
   @Expose()
-  responsibleId: string
+  responsibleId: number
 
   @ApiProperty({
     description: 'descripción del almacén',

--- a/src/core/warehouses/warehouses.controller.ts
+++ b/src/core/warehouses/warehouses.controller.ts
@@ -5,7 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
-  ParseUUIDPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -40,7 +40,7 @@ export class WarehousesController {
     summary: 'Obtener un almacén por id',
   })
   @ApiStandardResponse(WarehouseResDto, HttpStatus.OK)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.service.findOne(id)
   }
 
@@ -61,7 +61,7 @@ export class WarehousesController {
   @ApiBody({ type: UpdateWarehouseDto })
   @ApiStandardResponse(WarehouseResDto, HttpStatus.OK)
   update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateWarehouseDto,
   ) {
     return this.service.update(id, dto)
@@ -72,7 +72,7 @@ export class WarehousesController {
     summary: 'Eliminar un almacén por id',
   })
   @ApiStandardResponse(WarehouseResDto, HttpStatus.OK)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIntPipe) id: number) {
     return this.service.remove(id)
   }
 }

--- a/src/core/warehouses/warehouses.service.ts
+++ b/src/core/warehouses/warehouses.service.ts
@@ -53,7 +53,7 @@ export class WarehousesService {
     }
   }
 
-  async findOne(id: string) {
+  async findOne(id: number) {
     const [record] = await this.dbService.db
       .select(this.warehousesWithoutDates)
       .from(warehouse)
@@ -83,7 +83,7 @@ export class WarehousesService {
     return plainToInstance(WarehouseResDto, newWarehouse)
   }
 
-  async update(id: string, dto: UpdateWarehouseDto) {
+  async update(id: number, dto: UpdateWarehouseDto) {
     await this.findOne(id)
 
     const [updatedWarehouse] = await this.dbService.db
@@ -96,7 +96,7 @@ export class WarehousesService {
     return plainToInstance(WarehouseResDto, updatedWarehouse)
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.findOne(id)
 
     const [deletedWarehouse] = await this.dbService.db

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,10 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "paths": {
+      "drizzle/schema": ["./drizzle/schema"],
+      "drizzle/schema/*": ["./drizzle/schema/*"]
+    }
   }
 }


### PR DESCRIPTION
This pull request updates the database schema for several inventory-related tables. The changes primarily involve replacing `uuid` primary keys with `serial` primary keys and converting foreign key references from `uuid` to `integer`. Additionally, some new relations are defined to improve schema clarity and consistency.

### Primary Key Changes:
* Replaced `uuid` primary keys with `serial` primary keys across all affected tables, including `assetLoan`, `assetValue`, `category`, `certificate`, `color`, `condition`, `depreciation`, `exitDetail`, `exitProcess`, `insuranceClaim`, `insurancePolicy`, `insuredAssetDetail`, `item`, `itemColor`, `itemImage`, `itemMaterial`, `itemType`, and `maintenance`. (`[[1]](diffhunk://#diff-b07e739b30f02f7cd844b3889836f39a42766ee1523221b0562413e544d36b11L3-R3)`, `[[2]](diffhunk://#diff-5b0fbef6070687438dcde42742cc3c0c777dae7c3fbc39d3a7d1c0e5c0f60f06L3-R3)`, `[[3]](diffhunk://#diff-6312088907ff38ba18eb83e37c89a430b7bc1a38f0a06a112370314332554241L3-R19)`, `[[4]](diffhunk://#diff-93333e8005c0329d98ba4fd5a1306f121d9c20accd28ba9680e37e4128ea93deL3-R3)`, `[[5]](diffhunk://#diff-653f1e40ecb12e129e73f8641ae0358e4d416a103203e4ccb70c99000d6ec64cL3-R13)`, `[[6]](diffhunk://#diff-a4f0b8fa81be9d1aca705efe803c235039d19476c79152eca29085ca3b1dda31L3-R13)`, `[[7]](diffhunk://#diff-8d13bc8e699a17cd7e72966de9db43506199a0bd0d6072eb445b5dcaa7a6dbd3L3-R3)`, `[[8]](diffhunk://#diff-f198134d0470d4777b42a8bcfd38fe9aebfc03fe2ef9f0477e4b4ad879e1e618L3-R4)`, `[[9]](diffhunk://#diff-a4d9227f84f2070be7de8f9f2cb7f6b2078ac5f1be0cfbcbc58d7eddeb82b2b3L3-R3)`, `[[10]](diffhunk://#diff-3ebc6ae1ba669a7d3e3d1ae65d110464816c1ca769bbf2945efa268e8b8a1f3eL3-R4)`, `[[11]](diffhunk://#diff-ce528fc0b0765a6226f7322467aa7aba0e931f55d9b4d4424968c24361cc26dfL3-R3)`, `[[12]](diffhunk://#diff-147a0426ee11679974f60ff29555be26f9732eff99945b0ad0cb35223bc49370L3-R4)`, `[[13]](diffhunk://#diff-46516259e12a4f1c74e21f339c347a36a78d645fef33f5e6ff0024b275bd9bb5L3-R9)`, `[[14]](diffhunk://#diff-7d1068b826310d4431d86fb857e7b3a71a3c1df0ee331fe0d3e04ed038072f36L3-R3)`, `[[15]](diffhunk://#diff-1e1459d8de4b313a78dd8d85b1d3a19c8a8e009eb17eb7639d4cc57e72d44860L3-R4)`, `[[16]](diffhunk://#diff-43b78a31a4a4dc8a06ea336f9ca1edb5772430a659c8d7271fd198c47b3057a1L3-R3)`, `[[17]](diffhunk://#diff-f98de72925d72f64f4e9a89f033fd2fe1f9833544245224c00edf843af2a335eL3-R3)`, `[[18]](diffhunk://#diff-c15a47f34a47eceb94cb9cb48af62aaa85c31bde1d518fc5f6af7c151b5529d9L3-R3)`)

### Foreign Key Updates:
* Updated foreign key references to use `integer` instead of `uuid` for consistency with the new primary key type. This change affects relationships in tables such as `assetLoan`, `assetValue`, `category`, `certificate`, `depreciation`, `exitDetail`, `insuranceClaim`, `insuredAssetDetail`, `item`, `itemColor`, `itemImage`, `itemMaterial`, and `maintenance`. (`[[1]](diffhunk://#diff-b07e739b30f02f7cd844b3889836f39a42766ee1523221b0562413e544d36b11L16-R17)`, `[[2]](diffhunk://#diff-5b0fbef6070687438dcde42742cc3c0c777dae7c3fbc39d3a7d1c0e5c0f60f06L15-R16)`, `[[3]](diffhunk://#diff-6312088907ff38ba18eb83e37c89a430b7bc1a38f0a06a112370314332554241L3-R19)`, `[[4]](diffhunk://#diff-8d13bc8e699a17cd7e72966de9db43506199a0bd0d6072eb445b5dcaa7a6dbd3L14-R15)`, `[[5]](diffhunk://#diff-f198134d0470d4777b42a8bcfd38fe9aebfc03fe2ef9f0477e4b4ad879e1e618L17-R22)`, `[[6]](diffhunk://#diff-3ebc6ae1ba669a7d3e3d1ae65d110464816c1ca769bbf2945efa268e8b8a1f3eL16-R21)`, `[[7]](diffhunk://#diff-147a0426ee11679974f60ff29555be26f9732eff99945b0ad0cb35223bc49370L16-R21)`, `[[8]](diffhunk://#diff-46516259e12a4f1c74e21f339c347a36a78d645fef33f5e6ff0024b275bd9bb5L37-R53)`, `[[9]](diffhunk://#diff-7d1068b826310d4431d86fb857e7b3a71a3c1df0ee331fe0d3e04ed038072f36L16-R20)`, `[[10]](diffhunk://#diff-1e1459d8de4b313a78dd8d85b1d3a19c8a8e009eb17eb7639d4cc57e72d44860L14-R16)`, `[[11]](diffhunk://#diff-43b78a31a4a4dc8a06ea336f9ca1edb5772430a659c8d7271fd198c47b3057a1L16-R20)`, `[[12]](diffhunk://#diff-c15a47f34a47eceb94cb9cb48af62aaa85c31bde1d518fc5f6af7c151b5529d9R17-R21)`)

### New Relations:
* Added `maintenanceRelations` to define relationships between the `maintenance` table and related entities such as `item` and `user`. This improves schema clarity and enforces referential integrity. (`[drizzle/schema/tables/inventory/maintenance.tsR46-R56](diffhunk://#diff-c15a47f34a47eceb94cb9cb48af62aaa85c31bde1d518fc5f6af7c151b5529d9R46-R56)`)…stead of uuid