### PR TITLE
Feature/logical delete

### DIFF
--- a/drizzle/data/csv-importer/services/status-service.ts
+++ b/drizzle/data/csv-importer/services/status-service.ts
@@ -51,7 +51,7 @@ export const findStatusByName = async (
       .values({
         name: 'Activo',
         description: 'Estado por defecto',
-        requiresMaintenance: false,
+        active: false,
       })
       .returning()
 

--- a/drizzle/data/states.ts
+++ b/drizzle/data/states.ts
@@ -4,21 +4,21 @@ export const statesSeed: (typeof status.$inferInsert)[] = [
   {
     name: 'Activo',
     description: 'Activo',
-    requiresMaintenance: false,
+    active: false,
   },
   {
     name: 'En reparación',
     description: 'En reparación',
-    requiresMaintenance: true,
+    active: true,
   },
   {
     name: 'En servicio',
     description: 'En servicio',
-    requiresMaintenance: true,
+    active: true,
   },
   {
     name: 'En préstamo',
     description: 'En préstamo',
-    requiresMaintenance: true,
+    active: true,
   },
 ]

--- a/drizzle/schema/tables/inventory/item/itemColor.ts
+++ b/drizzle/schema/tables/inventory/item/itemColor.ts
@@ -25,6 +25,7 @@ export const itemColor = pgTable(
       withTimezone: true,
       mode: 'date',
     }).defaultNow(),
+    active: boolean('active').default(true),
     updateDate: timestamp('update_date', {
       withTimezone: true,
       mode: 'date',

--- a/drizzle/schema/tables/inventory/item/itemMaterial.ts
+++ b/drizzle/schema/tables/inventory/item/itemMaterial.ts
@@ -25,6 +25,7 @@ export const itemMaterial = pgTable(
       withTimezone: true,
       mode: 'date',
     }).defaultNow(),
+    active: boolean('active').default(true),
     updateDate: timestamp('update_date', {
       withTimezone: true,
       mode: 'date',

--- a/drizzle/schema/tables/inventory/status.ts
+++ b/drizzle/schema/tables/inventory/status.ts
@@ -15,7 +15,7 @@ export const status = pgTable('states', {
   id: serial('id').primaryKey(),
   name: varchar('name', { length: 50 }).notNull().unique(),
   description: text('description'),
-  requiresMaintenance: boolean('requires_maintenance').default(false),
+  active: boolean('requires_maintenance').default(true),
   registrationDate: timestamp('registration_date', {
     withTimezone: true,
     mode: 'date',

--- a/src/core/assets-value/assets-value.controller.ts
+++ b/src/core/assets-value/assets-value.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  Delete,
   Get,
   HttpStatus,
   Param,
@@ -67,12 +66,12 @@ export class AssetsValueController {
     return this.service.update(id, dto)
   }
 
-  @Delete(':id')
-  @ApiOperation({
-    summary: 'Delete a category by itemId',
-  })
-  @ApiStandardResponse(AssetValueResDto, HttpStatus.OK)
-  remove(@Param('id', ParseIntPipe) id: number) {
-    return this.service.remove(id)
-  }
+  // @Delete(':id')
+  // @ApiOperation({
+  //   summary: 'Delete a category by itemId',
+  // })
+  // @ApiStandardResponse(AssetValueResDto, HttpStatus.OK)
+  // remove(@Param('id', ParseIntPipe) id: number) {
+  //   return this.service.remove(id)
+  // }
 }

--- a/src/core/assets-value/assets-value.service.ts
+++ b/src/core/assets-value/assets-value.service.ts
@@ -131,20 +131,20 @@ export class AssetsValueService {
     return updateAssetValue
   }
 
-  async remove(id: number) {
-    await this.findByItemId(id)
+  // async remove(id: number) {
+  //   await this.findByItemId(id)
 
-    const [deletedAssetValue] = await this.dbService.db
-      .delete(assetValue)
-      .where(eq(assetValue.itemId, id))
-      .returning(this.assetValueWithoutDates)
-      .execute()
-    if (!deletedAssetValue) {
-      throw new DisplayableException(
-        `Error al eliminar el valor de activo para el item ${id}`,
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      )
-    }
-    return deletedAssetValue
-  }
+  //   const [deletedAssetValue] = await this.dbService.db
+  //     .delete(assetValue)
+  //     .where(eq(assetValue.itemId, id))
+  //     .returning(this.assetValueWithoutDates)
+  //     .execute()
+  //   if (!deletedAssetValue) {
+  //     throw new DisplayableException(
+  //       `Error al eliminar el valor de activo para el item ${id}`,
+  //       HttpStatus.INTERNAL_SERVER_ERROR,
+  //     )
+  //   }
+  //   return deletedAssetValue
+  // }
 }

--- a/src/core/item-colors/item-colors.service.ts
+++ b/src/core/item-colors/item-colors.service.ts
@@ -111,7 +111,8 @@ export class ItemColorsService {
     await this.findOne(id)
 
     const [deletedItemColor] = await this.dbService.db
-      .delete(itemColor)
+      .update(itemColor)
+      .set({ active: false })
       .where(eq(itemColor.id, id))
       .returning(this.itemColorsWithoutDates)
       .execute()

--- a/src/core/item-materials/item-materials.service.ts
+++ b/src/core/item-materials/item-materials.service.ts
@@ -111,7 +111,8 @@ export class ItemMaterialsService {
     await this.findOne(id)
 
     const [deleteditemMaterial] = await this.dbService.db
-      .delete(itemMaterial)
+      .update(itemMaterial)
+      .set({ active: false })
       .where(eq(itemMaterial.id, id))
       .returning(this.itemMaterialWithoutDates)
       .execute()

--- a/src/core/states/dto/req/create-status.dto.ts
+++ b/src/core/states/dto/req/create-status.dto.ts
@@ -19,10 +19,10 @@ export class CreateStatusDto {
   description?: string
 
   @ApiProperty({
-    description: 'requiresMaintenance (is optional)',
-    example: 'false',
+    description: 'active (is optional)',
+    example: 'true',
   })
-  @IsBoolean({ message: 'requiresMaintenance must be a boolean' })
+  @IsBoolean({ message: 'active must be a boolean' })
   @IsOptional()
-  requiresMaintenance?: boolean
+  active?: boolean
 }

--- a/src/core/states/dto/res/status-res.dto.ts
+++ b/src/core/states/dto/res/status-res.dto.ts
@@ -23,5 +23,5 @@ export class StatusResDto {
     description: 'requiresMaintenance of the status',
     example: 5,
   })
-  requiresMaintenance: boolean
+  active: boolean
 }

--- a/src/core/states/states.service.ts
+++ b/src/core/states/states.service.ts
@@ -79,7 +79,7 @@ export class StatesService {
       .values({
         name: dto.name,
         description: dto.description,
-        requiresMaintenance: dto.requiresMaintenance,
+        active: dto.active,
       })
       .returning(this.statesWithoutDates)
       .execute()
@@ -108,7 +108,7 @@ export class StatesService {
 
     const [deletedStatus] = await this.dbService.db
       .update(status)
-      .set({ requiresMaintenance: false, updateDate: new Date() })
+      .set({ active: false, updateDate: new Date() })
       .where(eq(status.id, id))
       .returning(this.statesWithoutDates)
       .execute()


### PR DESCRIPTION
This pull request introduces a significant refactor to replace the `requiresMaintenance` property with a new `active` property across multiple modules, alongside updates to the behavior of deletion operations for certain entities. The changes aim to standardize the property name, improve clarity, and implement soft deletion for better data management.

### Refactor: Replace `requiresMaintenance` with `active`

* Updated the `status` table schema to replace the `requiresMaintenance` column with `active` and set its default value to `true`. (`drizzle/schema/tables/inventory/status.ts`, [drizzle/schema/tables/inventory/status.tsL18-R18](diffhunk://#diff-6388126f0cbcb6ca0158045a41b77465391de3e05cfe2e4e2a60ff69433d5a99L18-R18))
* Refactored DTOs (`CreateStatusDto` and `StatusResDto`) to rename `requiresMaintenance` to `active` and adjusted validation and API documentation accordingly. (`src/core/states/dto/req/create-status.dto.ts`, [[1]](diffhunk://#diff-72105f96b2ed8908cc64dbff3b660df594149e88bf3f4221753cf6aa74e68d83L22-R27); `src/core/states/dto/res/status-res.dto.ts`, [[2]](diffhunk://#diff-a5f74b026f9ddc886319e634edb4e2fa7e295ab705bce9a5447f2c5a87ce71b9L26-R26)
* Updated the `statesSeed` data and `findStatusByName` method to use the `active` property instead of `requiresMaintenance`. (`drizzle/data/states.ts`, [[1]](diffhunk://#diff-ca7e0ad24d2974dbb135cd35494f83d574413149616f95bb581e46e14e5b0a52L7-R22); `drizzle/data/csv-importer/services/status-service.ts`, [[2]](diffhunk://#diff-f3589b45fb93d7ba2ce36c2d544f18e20eb87ba690c5e9ee88e74bd4967f793dL54-R54)
* Modified the `StatesService` to handle the `active` property during creation and updates. (`src/core/states/states.service.ts`, [[1]](diffhunk://#diff-13dbb0fc6fab86cc2495879e4ed7ae05bbeba01ccfddfc45f9f67020383c747dL82-R82) [[2]](diffhunk://#diff-13dbb0fc6fab86cc2495879e4ed7ae05bbeba01ccfddfc45f9f67020383c747dL111-R111)

### Soft Deletion Implementation

* Replaced hard deletion with soft deletion by introducing the `active` column in the `itemColor` and `itemMaterial` tables, defaulting to `true`. (`drizzle/schema/tables/inventory/item/itemColor.ts`, [[1]](diffhunk://#diff-7d1068b826310d4431d86fb857e7b3a71a3c1df0ee331fe0d3e04ed038072f36R28); `drizzle/schema/tables/inventory/item/itemMaterial.ts`, [[2]](diffhunk://#diff-43b78a31a4a4dc8a06ea336f9ca1edb5772430a659c8d7271fd198c47b3057a1R28)
* Updated the `ItemColorsService` and `ItemMaterialsService` to deactivate records by setting `active` to `false` instead of deleting them. (`src/core/item-colors/item-colors.service.ts`, [[1]](diffhunk://#diff-492397b7ac1e4952e7c1928ef91cd6962ce1f038870315dcc1aa21c4e0069967L114-R115); `src/core/item-materials/item-materials.service.ts`, [[2]](diffhunk://#diff-d2ce94e550b3d0e135415f01eafb7e64c0cece1de0b1d4c0d25c58496bdc78caL114-R115)

### Deprecation of Asset Deletion

* Commented out the `remove` method in `AssetsValueController` and `AssetsValueService`, effectively deprecating the deletion functionality for assets. (`src/core/assets-value/assets-value.controller.ts`, [[1]](diffhunk://#diff-c3a2376502f2d0300ac2c77201f5373989be989610670514746c257ef5e8640cL4) [[2]](diffhunk://#diff-c3a2376502f2d0300ac2c77201f5373989be989610670514746c257ef5e8640cL70-R76); `src/core/assets-value/assets-value.service.ts`, [[3]](diffhunk://#diff-458290d47c7aad204f9cd3dd1966f6601d82951b311ab22772135d7472e73cc2L134-R149)